### PR TITLE
Update DEA.R

### DIFF
--- a/bin/DEA.R
+++ b/bin/DEA.R
@@ -321,7 +321,7 @@ DESeq2 <- function(inputdata, data_type){
         design = inputdata$design)
         tmp <- DESeq(tmp, quiet=TRUE)
 
-        sizefactors <- sizeFactors(tmp)
+        sizefactors <- estimateSizeFactorsForMatrix(counts(tmp))
         rm(tmp)
 
         dds <- DESeqDataSetFromMatrix(


### PR DESCRIPTION
sizeFactors(tmp) produces NULL instead of the size factors
estimateSizeFactorsForMatrix(counts(tmp)) results in a vector containing each sample's size factors
