### PR TITLE
bash script BSJ sites to miRNA algos

### DIFF
--- a/bin/backsplice_gen.sh
+++ b/bin/backsplice_gen.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+## .fa = backsplice .fasta = canonical to publish
+
+file_prefix=$(basename $1 .fa)
+
+# Split multi-fasta file into single records
+mkdir canonical_seqs && mv $1 canonical_seqs/
+ls -d canonical_seqs/*.fa | while read -r line; do
+  cat $line | awk '{if (substr($0, 1, 1)==">") {filename=(substr($0,2) ".fa")} print $0 > filename}'
+done
+
+# add backsplice site to individual fasta files
+for file in *.fa; do
+  fn=$(basename $file .fa)
+  cat $file | grep ">" > header.txt
+  cat $file | grep -v ">" | cut -c1-20 > 20bp.txt
+  cat $file | grep -v ">" > seqs.txt
+  paste seqs.txt 20bp.txt | sed -e 's/\t//' > seqs_20bp.txt
+  paste header.txt seqs_20bp.txt | sed -e 's/\t/\n/' > ${fn}.fasta
+  rm header.txt 20bp.txt seqs.txt seqs_20bp.txt
+done
+
+# rm single fasta entries from while read line
+rm *.fa
+# merge backsplice fastas into one for miRNA pred
+cat *.fasta > ${file_prefix}.fa
+# remove intermediate for loop fasta file
+rm *.fasta
+# move canonical seqs back to publish to outdir
+ls -d canonical_seqs/*.fa | while read -r line; do
+  mv $line ${file_prefix}.fasta
+done

--- a/main.nf
+++ b/main.nf
@@ -1472,7 +1472,7 @@ process ANNOTATION{
 
 process FASTA{
     tag "${base}:${tool}"
-    publishDir "${params.outdir}/circrna_discovery/${tool}/${base}", mode: params.publish_dir_mode, pattern: "*.fa"
+    publishDir "${params.outdir}/circrna_discovery/${tool}/${base}", mode: params.publish_dir_mode, pattern: "*.fasta"
 
     input:
     tuple val(base), val(tool), file(bed) from ch_annotation
@@ -1480,6 +1480,7 @@ process FASTA{
 
     output:
     tuple val(base), val(tool), file("${base}.fa") into ch_mature_len_miranda, ch_mature_len_targetscan
+    file("${base}.fasta") into publish_circ_mature_seq
 
     script:
     """
@@ -1488,6 +1489,8 @@ process FASTA{
     bedtools getfasta -fi $fasta -bed bed12.tmp -s -split -name > circ_seq.tmp
     ## clean fasta header
     grep -A 1 '>' circ_seq.tmp | cut -d: -f1,2,3 > ${base}.fa && rm circ_seq.tmp
+    ## add backsplice sequence for miRanda TargetScan, publish canonical FASTA to results.
+    bash ${workflow.projectDir}/bin/backsplice_gen.sh ${base}.fa
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -1490,6 +1490,7 @@ process FASTA{
     ## clean fasta header
     grep -A 1 '>' circ_seq.tmp | cut -d: -f1,2,3 > ${base}.fa && rm circ_seq.tmp
     ## add backsplice sequence for miRanda TargetScan, publish canonical FASTA to results.
+    rm $fasta
     bash ${workflow.projectDir}/bin/backsplice_gen.sh ${base}.fa
     """
 }


### PR DESCRIPTION
Reviewer comments, adding circRNA back splice sequence to miRNA prediction tools:

* Take the first 20bp and append to the end of the circRNA mature sequence fasta file, mimicking the BSJ site. 
* Strand orientation has been taken care of upstream in the annotation script using bedtools. 