### PR TITLE
resolve two bugs: error for tmp dir when running 'sort' on cluster AND channel value for STAR index for multiple sampels

### DIFF
--- a/modules/local/star/sjdb/main.nf
+++ b/modules/local/star/sjdb/main.nf
@@ -23,7 +23,7 @@ process SJDB {
     """
     mkdir tmp
     cat *.tab | awk -v BSJ=${bsj_reads} '(\$7 >= BSJ && \$6==0)' | cut -f1-6 | sort -T ./tmp/ | uniq > dataset.SJ.out.tab
-
+rm -rf tmp
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         mawk: $VERSION

--- a/modules/local/star/sjdb/main.nf
+++ b/modules/local/star/sjdb/main.nf
@@ -21,7 +21,7 @@ process SJDB {
     script:
     def VERSION = '1.3.4'
     """
-    cat *.tab | awk -v BSJ=${bsj_reads} '(\$7 >= BSJ && \$6==0)' | cut -f1-6 | sort | uniq > dataset.SJ.out.tab
+    cat *.tab | awk -v BSJ=${bsj_reads} '(\$7 >= BSJ && \$6==0)' | cut -f1-6 | sort -T ./tmp/ | uniq > dataset.SJ.out.tab
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/star/sjdb/main.nf
+++ b/modules/local/star/sjdb/main.nf
@@ -21,6 +21,7 @@ process SJDB {
     script:
     def VERSION = '1.3.4'
     """
+    mkdir tmp
     cat *.tab | awk -v BSJ=${bsj_reads} '(\$7 >= BSJ && \$6==0)' | cut -f1-6 | sort -T ./tmp/ | uniq > dataset.SJ.out.tab
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/star/sjdb/main.nf
+++ b/modules/local/star/sjdb/main.nf
@@ -23,7 +23,7 @@ process SJDB {
     """
     mkdir tmp
     cat *.tab | awk -v BSJ=${bsj_reads} '(\$7 >= BSJ && \$6==0)' | cut -f1-6 | sort -T ./tmp/ | uniq > dataset.SJ.out.tab
-rm -rf tmp
+    rm -rf tmp
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         mawk: $VERSION

--- a/subworkflows/local/circrna_discovery.nf
+++ b/subworkflows/local/circrna_discovery.nf
@@ -85,10 +85,10 @@ workflow CIRCRNA_DISCOVERY {
     seq_center     = params.seq_center ?: ''
     seq_platform   = ''
 
-    STAR_1ST_PASS( reads, star_index, gtf_tuple, star_ignore_sjdbgtf, seq_platform, seq_center)
+    STAR_1ST_PASS( reads, star_index.first(), gtf_tuple, star_ignore_sjdbgtf, seq_platform, seq_center)
     sjdb = STAR_1ST_PASS.out.tab.map{ meta, tab -> return tab }.collect().map{[[id: "star_sjdb"], it]}
     STAR_SJDB( sjdb, bsj_reads )
-    STAR_2ND_PASS( reads, star_index, STAR_SJDB.out.sjtab, star_ignore_sjdbgtf, seq_platform, seq_center )
+    STAR_2ND_PASS( reads, star_index.first(), STAR_SJDB.out.sjtab, star_ignore_sjdbgtf, seq_platform, seq_center )
 
     ch_versions = ch_versions.mix(STAR_1ST_PASS.out.versions)
     ch_versions = ch_versions.mix(STAR_2ND_PASS.out.versions)
@@ -155,14 +155,14 @@ workflow CIRCRNA_DISCOVERY {
     //
 
     mate1 = reads.filter{ meta, reads -> !meta.single_end }.map{ meta, reads -> return [ [id: meta.id, single_end: true], reads[0] ] }
-    DCC_MATE1_1ST_PASS( mate1, star_index, gtf_tuple, star_ignore_sjdbgtf, seq_platform, seq_center )
+    DCC_MATE1_1ST_PASS( mate1, star_index.first(), gtf_tuple, star_ignore_sjdbgtf, seq_platform, seq_center )
     DCC_MATE1_SJDB( DCC_MATE1_1ST_PASS.out.tab.map{ meta, tab -> return tab }.collect().map{[[id: "mate1_sjdb"], it]}, bsj_reads )
-    DCC_MATE1_2ND_PASS( mate1, star_index, DCC_MATE1_SJDB.out.sjtab, star_ignore_sjdbgtf, seq_platform, seq_center )
+    DCC_MATE1_2ND_PASS( mate1, star_index.first(), DCC_MATE1_SJDB.out.sjtab, star_ignore_sjdbgtf, seq_platform, seq_center )
 
     mate2 = reads.filter{ meta, reads -> !meta.single_end }.map{ meta, reads -> return [ [id: meta.id, single_end: true], reads[1] ] }
-    DCC_MATE2_1ST_PASS( mate2, star_index, gtf_tuple, star_ignore_sjdbgtf, seq_platform, seq_center )
+    DCC_MATE2_1ST_PASS( mate2, star_index.first(), gtf_tuple, star_ignore_sjdbgtf, seq_platform, seq_center )
     DCC_MATE2_SJDB( DCC_MATE2_1ST_PASS.out.tab.map{ meta, tab -> return tab }.collect().map{[[id: "mate2_sjdb"], it]}, bsj_reads )
-    DCC_MATE2_2ND_PASS( mate2, star_index, DCC_MATE2_SJDB.out.sjtab, star_ignore_sjdbgtf, seq_platform, seq_center )
+    DCC_MATE2_2ND_PASS( mate2, star_index.first(), DCC_MATE2_SJDB.out.sjtab, star_ignore_sjdbgtf, seq_platform, seq_center )
 
     dcc_stage = STAR_2ND_PASS.out.junction.map{ meta, junction -> return [ meta.id, meta, junction]}
         .join(


### PR DESCRIPTION
When running the pipeline on a cluster, I got this error:

`sort: cannot create temporary file in '/scratch/23638855.torque6.curie.fr': No such file or directory`

during the `NFCORE_CIRCRNA:CIRCRNA:CIRCRNA_DISCOVERY:STAR_SJDB` step.

Following a suggestion in this [issue](https://github.com/nf-core/chipseq/issues/123) from another nf-core pipeline, I added the `sort -T ./tmp/` flag to redirect the tmp files.
