### PR TITLE
Fix script references

### DIFF
--- a/modules/local/count_matrix/single/main.nf
+++ b/modules/local/count_matrix/single/main.nf
@@ -29,12 +29,12 @@ process COUNTS_SINGLE {
         mv \$b \${sample_name}.bed
     done
 
-    python ${workflow.projectDir}/bin/circRNA_counts_matrix.py > matrix.txt
+    circRNA_counts_matrix.py > matrix.txt
     ## handle non-canon chromosomes here (https://stackoverflow.com/questions/71479919/joining-columns-based-on-number-of-fields)
     n_samps=\$(ls *.bed | wc -l)
     canon=\$(awk -v a="\$n_samps" 'BEGIN {print a + 4}')
     awk -v n="\$canon" '{ for (i = 2; i <= NF - n + 1; ++i) { \$1 = \$1"-"\$i; \$i=""; } } 1' matrix.txt | awk -v OFS="\\t" '\$1=\$1' > circRNA_matrix.txt
-    Rscript ${workflow.projectDir}/bin/reformat_count_matrix.R
+    reformat_count_matrix.R
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
With this PR we remove the last remaining script references via `${workflow.projectDir}` in favor of the automatic mount of the `bin` directory. This artifact caused problems when users executed the pipeline with a single circRNA detection tool.

This is pretty much free of risks, since it has been working like this in [this process](https://github.com/nf-core/circrna/blob/d7fe40ff72541a7e40d8c1a07c5ce68874eba333/modules/local/count_matrix/combined/main.nf#L23) flawlessly for some time now.