### PR TITLE
Resolving tiny ciriquant bug

### DIFF
--- a/modules/local/ciriquant/ciriquant/main.nf
+++ b/modules/local/ciriquant/ciriquant/main.nf
@@ -24,6 +24,9 @@ process CIRIQUANT {
     prefix = task.ext.prefix ?: "${meta.id}"
     def VERSION = '2.1.0'
     """
+    mkdir -p ${prefix}
+    mkdir -p ${prefix}/circ
+    touch ${prefix}/circ/${prefix}.ciri
     CIRIquant \\
         -t ${task.cpus} \\
         -1 ${reads[0]} \\

--- a/modules/local/ciriquant/ciriquant/main.nf
+++ b/modules/local/ciriquant/ciriquant/main.nf
@@ -24,9 +24,6 @@ process CIRIQUANT {
     prefix = task.ext.prefix ?: "${meta.id}"
     def VERSION = '2.1.0'
     """
-    mkdir -p ${prefix}
-    mkdir -p ${prefix}/circ
-    touch ${prefix}/circ/${prefix}.ciri
     CIRIquant \\
         -t ${task.cpus} \\
         -1 ${reads[0]} \\

--- a/modules/local/ciriquant/yml/main.nf
+++ b/modules/local/ciriquant/yml/main.nf
@@ -19,7 +19,7 @@ process CIRIQUANT_YML {
     task.ext.when == null || task.ext.when
 
     script:
-    hisat2_prefix = meta2.id
+    hisat2_prefix = fasta.toString() - ~/.(fa|fasta)$/
     fasta_path = fasta.toRealPath()
     gtf_path = gtf.toRealPath()
     bwa_path = bwa.toRealPath()

--- a/modules/local/ciriquant/yml/main.nf
+++ b/modules/local/ciriquant/yml/main.nf
@@ -19,7 +19,7 @@ process CIRIQUANT_YML {
     task.ext.when == null || task.ext.when
 
     script:
-    hisat2_prefix = fasta.toString() - ~/.(fa|fasta)$/
+    hisat2_prefix = fasta.baseName
     fasta_path = fasta.toRealPath()
     gtf_path = gtf.toRealPath()
     bwa_path = bwa.toRealPath()


### PR DESCRIPTION
Recently I've encountered two bugs when running ciriquant.

One is described in more detail in this [issue](https://github.com/nf-core/circrna/issues/108) (see mostly the second comment). In short, the yml file where the hisat2 index is specified did not contain the correct index name anymore after another commit in the pipeline.

I am not very familiar with how the pipeline works, so in this PR I just reverted the change. This seems to do the trick, but I'm not sure if this is good practice. I'm assuming there was a good reason to change the way the `hisat2_prefix` was set in the previous commit, so I would be glad if anyone could explain!

A second issue I encountered, was this error message also during the CIRIQUANT process:
`[Thu 2024-04-11 10:25:54] [INFO ] Running CIRI2 for circRNA detection ..
Traceback (most recent call last):
  File "/usr/local/bin/CIRIquant", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/site-packages/CIRIquant/main.py", line 183, in main
    circ_parser.convert(bed_file)
  File "/usr/local/lib/python2.7/site-packages/CIRIquant/utils.py", line 239, in convert
    circ_data = getattr(self, '_' + self.tool.lower())()
  File "/usr/local/lib/python2.7/site-packages/CIRIquant/utils.py", line 146, in _ciri2
    with open(self.circ, 'r') as f:
IOError: [Errno 2] No such file or directory: '/Users/marieke/Documents/ciriquant/work/4d/1836ef6340f9708ba469d4a289e0ca/fust1_1/circ/fust1_1.ciri'`

I've solved this by just adding an `mkdir` and `touch` command to create the necessary directories and file in the CIRIQUANT process. Again, it looks like it works, but I'm not sure if this is good practice, so any advise is welcome. The output files seem 'normal'.

This can all be tested by running:
`nextflow run circrna -profile test,docker --tool ciriquant`
