### PR TITLE
Add parameter for setting STAR limitSjdbInsertNsj

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -197,6 +197,7 @@ if (!params.skip_trimming) {
             "--outReadsUnmapped None",
             "--readFilesCommand zcat",
             "--alignSJDBoverhangMin ${params.alignSJDBoverhangMin}",
+            "--limitSjdbInsertNsj ${params.limitSjdbInsertNsj}",
             "--chimJunctionOverhangMin ${params.chimJunctionOverhangMin}",
             "--chimSegmentMin ${params.chimSegmentMin}"
         ].join(' ').trim()
@@ -228,6 +229,7 @@ if (!params.skip_trimming) {
             "--readFilesCommand zcat",
             "--sjdbFileChrStartEnd dataset.SJ.out.tab",
             "--alignSJDBoverhangMin ${params.alignSJDBoverhangMin}",
+            "--limitSjdbInsertNsj ${params.limitSjdbInsertNsj}",
             "--chimJunctionOverhangMin ${params.chimJunctionOverhangMin}",
             "--chimSegmentMin ${params.chimSegmentMin}"
         ].join(' ').trim()
@@ -395,6 +397,7 @@ if (!params.skip_trimming) {
             "--outReadsUnmapped None",
             "--readFilesCommand zcat",
             "--alignSJDBoverhangMin ${params.alignSJDBoverhangMin}",
+            "--limitSjdbInsertNsj ${params.limitSjdbInsertNsj}",
             "--chimJunctionOverhangMin ${params.chimJunctionOverhangMin}",
             "--chimSegmentMin ${params.chimSegmentMin}"
         ].join(' ').trim()
@@ -426,6 +429,7 @@ if (!params.skip_trimming) {
             "--readFilesCommand zcat",
             "--sjdbFileChrStartEnd dataset.SJ.out.tab",
             "--alignSJDBoverhangMin ${params.alignSJDBoverhangMin}",
+            "--limitSjdbInsertNsj ${params.limitSjdbInsertNsj}",
             "--chimJunctionOverhangMin ${params.chimJunctionOverhangMin}",
             "--chimSegmentMin ${params.chimSegmentMin}"
         ].join(' ').trim()
@@ -447,6 +451,7 @@ if (!params.skip_trimming) {
             "--outReadsUnmapped None",
             "--readFilesCommand zcat",
             "--alignSJDBoverhangMin ${params.alignSJDBoverhangMin}",
+            "--limitSjdbInsertNsj ${params.limitSjdbInsertNsj}",
             "--chimJunctionOverhangMin ${params.chimJunctionOverhangMin}",
             "--chimSegmentMin ${params.chimSegmentMin}"
         ].join(' ').trim()
@@ -479,6 +484,7 @@ if (!params.skip_trimming) {
             "--readFilesCommand zcat",
             "--sjdbFileChrStartEnd dataset.SJ.out.tab",
             "--alignSJDBoverhangMin ${params.alignSJDBoverhangMin}",
+            "--limitSjdbInsertNsj ${params.limitSjdbInsertNsj}",
             "--chimJunctionOverhangMin ${params.chimJunctionOverhangMin}",
             "--chimSegmentMin ${params.chimSegmentMin}"
         ].join(' ').trim()
@@ -500,6 +506,7 @@ if (!params.skip_trimming) {
             "--outReadsUnmapped None",
             "--readFilesCommand zcat",
             "--alignSJDBoverhangMin ${params.alignSJDBoverhangMin}",
+            "--limitSjdbInsertNsj ${params.limitSjdbInsertNsj}",
             "--chimJunctionOverhangMin ${params.chimJunctionOverhangMin}",
             "--chimSegmentMin ${params.chimSegmentMin}"
         ].join(' ').trim()
@@ -532,6 +539,7 @@ if (!params.skip_trimming) {
             "--readFilesCommand zcat",
             "--sjdbFileChrStartEnd dataset.SJ.out.tab",
             "--alignSJDBoverhangMin ${params.alignSJDBoverhangMin}",
+            "--limitSjdbInsertNsj ${params.limitSjdbInsertNsj}",
             "--chimJunctionOverhangMin ${params.chimJunctionOverhangMin}",
             "--chimSegmentMin ${params.chimSegmentMin}"
         ].join(' ').trim()

--- a/nextflow.config
+++ b/nextflow.config
@@ -54,6 +54,7 @@ params {
     alignSJDBoverhangMin       = 10
     chimSegmentMin             = 10
     sjdboverhang               = 100
+    limitSjdbInsertNsj         = 1000000
 
     //> MAPSPLICE
     seglen                     = 25

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -125,6 +125,11 @@
                     "description": "Minimum overhang for annotated junctions",
                     "default": 10
                 },
+                "limitSjdbInsertNsj": {
+                    "type": "integer",
+                    "description": "Maximum number of junction to be inserted to the genome on the fly at the mapping stage, including those from annotations and those detected in the 1st step of the 2-pass run",
+                    "default": 1000000
+                },
                 "chimSegmentMin": {
                     "type": "integer",
                     "description": "Minimum length of chimeric segment length. Must be set to a positive value to detect circular junctions.",


### PR DESCRIPTION
For larger runs, often there is an error message like this:

```
Command error:
 Fatal LIMIT error: the number of junctions to be inserted on the fly =2036958 is larger than the limitSjdbInsertNsj=1000000
 Fatal LIMIT error: the number of junctions to be inserted on the fly =2036958 is larger than the limitSjdbInsertNsj=1000000
 SOLUTION: re-run with at least --limitSjdbInsertNsj 2036958
```

Although it would be possible to override this using `ext.args`, this way it will be a bit easier for users.