### PR TITLE
Segemehl update

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -32,7 +32,7 @@
                     },
                     "bowtie2/align": {
                         "branch": "master",
-                        "git_sha": "0fe30831abbc2ed115e46e92330edf38f56edc3d",
+                        "git_sha": "e4bad511789f16d0df39ee306b2cd50418365048",
                         "installed_by": ["modules"]
                     },
                     "bowtie2/build": {
@@ -42,7 +42,7 @@
                     },
                     "bwa/index": {
                         "branch": "master",
-                        "git_sha": "6278bf9afd4a4b2d00fa6052250e73da3d91546f",
+                        "git_sha": "086fa66260595e123b0ea47a6512539b72a9afa3",
                         "installed_by": ["modules"]
                     },
                     "cat/cat": {
@@ -52,7 +52,7 @@
                     },
                     "cat/fastq": {
                         "branch": "master",
-                        "git_sha": "0997b47c93c06b49aa7b3fefda87e728312cf2ca",
+                        "git_sha": "4fc983ad0b30e6e32696fa7d980c76c7bfe1c03e",
                         "installed_by": ["modules"]
                     },
                     "circexplorer2/annotate": {
@@ -67,12 +67,12 @@
                     },
                     "csvtk/join": {
                         "branch": "master",
-                        "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
+                        "git_sha": "614abbf126f287a3068dc86997b2e1b6a93abe20",
                         "installed_by": ["modules"]
                     },
                     "csvtk/split": {
                         "branch": "master",
-                        "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
+                        "git_sha": "614abbf126f287a3068dc86997b2e1b6a93abe20",
                         "installed_by": ["modules"]
                     },
                     "custom/dumpsoftwareversions": {
@@ -92,7 +92,7 @@
                     },
                     "gawk": {
                         "branch": "master",
-                        "git_sha": "b42fec6f7c6e5d0716685cabb825ef6bf6e386b5",
+                        "git_sha": "cf3ed075695639b0a0924eb0901146df1996dc08",
                         "installed_by": ["modules"]
                     },
                     "gnu/sort": {
@@ -162,7 +162,7 @@
                     },
                     "segemehl/align": {
                         "branch": "master",
-                        "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
+                        "git_sha": "9a6b0745dbb5359286d36dee2183ffab240abba0",
                         "installed_by": ["modules"]
                     },
                     "segemehl/index": {
@@ -192,7 +192,7 @@
                     },
                     "tximeta/tximport": {
                         "branch": "master",
-                        "git_sha": "c275c3baac6df8f0c7c500760a0cf014ce7b525d",
+                        "git_sha": "5d095e8413da1f4c72b7d07ce87f75c09482486f",
                         "installed_by": ["modules"]
                     }
                 }

--- a/modules/nf-core/bowtie2/align/main.nf
+++ b/modules/nf-core/bowtie2/align/main.nf
@@ -1,6 +1,6 @@
 process BOWTIE2_ALIGN {
     tag "$meta.id"
-    label "process_high"
+    label 'process_high'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/nf-core/bowtie2/align/meta.yml
+++ b/modules/nf-core/bowtie2/align/meta.yml
@@ -36,6 +36,15 @@ input:
       type: file
       description: Bowtie2 genome index files
       pattern: "*.ebwt"
+  - meta3:
+      type: map
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'test', single_end:false ]
+  - fasta:
+      type: file
+      description: Bowtie2 genome fasta file
+      pattern: "*.fasta"
   - save_unaligned:
       type: boolean
       description: |
@@ -46,22 +55,38 @@ input:
       description: use samtools sort (true) or samtools view (false)
       pattern: "true or false"
 output:
-  - aligned:
+  - sam:
       type: file
-      description: Output BAM/SAM file containing read alignments
-      pattern: "*.{bam,sam}"
-  - versions:
+      description: Output SAM file containing read alignments
+      pattern: "*.sam"
+  - bam:
       type: file
-      description: File containing software versions
-      pattern: "versions.yml"
-  - fastq:
+      description: Output BAM file containing read alignments
+      pattern: "*.bam"
+  - cram:
       type: file
-      description: Unaligned FastQ files
-      pattern: "*.fastq.gz"
+      description: Output CRAM file containing read alignments
+      pattern: "*.cram"
+  - csi:
+      type: file
+      description: Output SAM/BAM index for large inputs
+      pattern: "*.csi"
+  - crai:
+      type: file
+      description: Output CRAM index
+      pattern: "*.crai"
   - log:
       type: file
       description: Aligment log
       pattern: "*.log"
+  - fastq:
+      type: file
+      description: Unaligned FastQ files
+      pattern: "*.fastq.gz"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
   - "@joseespinosa"
   - "@drpatelh"

--- a/modules/nf-core/bwa/index/environment.yml
+++ b/modules/nf-core/bwa/index/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::bwa=0.7.17
+  - bioconda::bwa=0.7.18

--- a/modules/nf-core/bwa/index/main.nf
+++ b/modules/nf-core/bwa/index/main.nf
@@ -4,8 +4,8 @@ process BWA_INDEX {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/bwa:0.7.17--hed695b0_7' :
-        'biocontainers/bwa:0.7.17--hed695b0_7' }"
+        'https://depot.galaxyproject.org/singularity/bwa:0.7.18--he4a0461_0' :
+        'biocontainers/bwa:0.7.18--he4a0461_0' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/nf-core/bwa/index/meta.yml
+++ b/modules/nf-core/bwa/index/meta.yml
@@ -43,3 +43,4 @@ authors:
 maintainers:
   - "@drpatelh"
   - "@maxulysse"
+  - "@gallvp"

--- a/modules/nf-core/bwa/index/tests/main.nf.test.snap
+++ b/modules/nf-core/bwa/index/tests/main.nf.test.snap
@@ -17,7 +17,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,0f20525da90e7489a7ebb02adca3265f"
+                    "versions.yml:md5,a64462ac7dfb21f4ade9b02e7f65c5bb"
                 ],
                 "index": [
                     [
@@ -34,10 +34,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,0f20525da90e7489a7ebb02adca3265f"
+                    "versions.yml:md5,a64462ac7dfb21f4ade9b02e7f65c5bb"
                 ]
             }
         ],
-        "timestamp": "2023-10-17T17:20:20.180927714"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-16T11:40:09.925307"
     }
 }

--- a/modules/nf-core/cat/fastq/tests/main.nf.test
+++ b/modules/nf-core/cat/fastq/tests/main.nf.test
@@ -1,3 +1,5 @@
+// NOTE The version snaps may not be consistant
+// https://github.com/nf-core/modules/pull/4087#issuecomment-1767948035
 nextflow_process {
 
     name "Test Process CAT_FASTQ"

--- a/modules/nf-core/csvtk/join/environment.yml
+++ b/modules/nf-core/csvtk/join/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::csvtk=0.26.0
+  - bioconda::csvtk=0.30.0

--- a/modules/nf-core/csvtk/join/main.nf
+++ b/modules/nf-core/csvtk/join/main.nf
@@ -4,8 +4,8 @@ process CSVTK_JOIN {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/csvtk:0.26.0--h9ee0642_0':
-        'biocontainers/csvtk:0.26.0--h9ee0642_0' }"
+        'https://depot.galaxyproject.org/singularity/csvtk:0.30.0--h9ee0642_0':
+        'biocontainers/csvtk:0.30.0--h9ee0642_0' }"
 
     input:
     tuple val(meta), path(csv)
@@ -36,7 +36,6 @@ process CSVTK_JOIN {
     """
 
     stub:
-    def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
     out_extension = args.contains('--out-delimiter "\t"') || args.contains('-D "\t"') || args.contains("-D \$'\t'") ? "tsv" : "csv"
     """

--- a/modules/nf-core/csvtk/join/tests/main.nf.test
+++ b/modules/nf-core/csvtk/join/tests/main.nf.test
@@ -1,0 +1,64 @@
+nextflow_process {
+
+    name "Test Process CSVTK_JOIN"
+    script "../main.nf"
+    process "CSVTK_JOIN"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "csvtk"
+    tag "csvtk/join"
+
+    test("join - csv") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file("https://github.com/nf-core/test-datasets/raw/bacass/bacass_hybrid.csv", checkIfExists: true),
+                        file("https://github.com/nf-core/test-datasets/raw/bacass/bacass_short.csv", checkIfExists: true),
+                    ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("join - csv - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file("https://github.com/nf-core/test-datasets/raw/bacass/bacass_hybrid.csv", checkIfExists: true),
+                        file("https://github.com/nf-core/test-datasets/raw/bacass/bacass_short.csv", checkIfExists: true),
+                    ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/csvtk/join/tests/main.nf.test.snap
+++ b/modules/nf-core/csvtk/join/tests/main.nf.test.snap
@@ -1,0 +1,60 @@
+{
+    "join - csv": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.csv:md5,d0ad82ca096c7e05eb9f9a04194c9e30"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,e76147e4eca968d23543e7007522f1d3"
+                ],
+                "csv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.csv:md5,d0ad82ca096c7e05eb9f9a04194c9e30"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,e76147e4eca968d23543e7007522f1d3"
+                ]
+            }
+        ],
+        "timestamp": "2024-05-21T15:45:44.045434"
+    },
+    "join - csv - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,e76147e4eca968d23543e7007522f1d3"
+                ],
+                "csv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,e76147e4eca968d23543e7007522f1d3"
+                ]
+            }
+        ],
+        "timestamp": "2024-05-21T15:45:55.59201"
+    }
+}

--- a/modules/nf-core/csvtk/join/tests/nextflow.config
+++ b/modules/nf-core/csvtk/join/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: CSVTK_JOIN {
+        ext.args = "--fields 'ID;ID' -p -e -d \"\t\" -D \",\""
+    }
+}

--- a/modules/nf-core/csvtk/join/tests/tags.yml
+++ b/modules/nf-core/csvtk/join/tests/tags.yml
@@ -1,0 +1,2 @@
+csvtk/join:
+  - "modules/nf-core/csvtk/join/**"

--- a/modules/nf-core/csvtk/split/environment.yml
+++ b/modules/nf-core/csvtk/split/environment.yml
@@ -1,6 +1,7 @@
+name: csvtk_split
 channels:
   - conda-forge
   - bioconda
   - defaults
 dependencies:
-  - bioconda::csvtk=0.23.0
+  - bioconda::csvtk=0.30.0

--- a/modules/nf-core/csvtk/split/main.nf
+++ b/modules/nf-core/csvtk/split/main.nf
@@ -4,8 +4,8 @@ process CSVTK_SPLIT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/csvtk:0.23.0--h9ee0642_0' :
-        'biocontainers/csvtk:0.23.0--h9ee0642_0' }"
+        'https://depot.galaxyproject.org/singularity/csvtk:0.30.0--h9ee0642_0' :
+        'biocontainers/csvtk:0.30.0--h9ee0642_0' }"
 
     input:
     tuple val(meta), path(csv)
@@ -38,6 +38,19 @@ process CSVTK_SPLIT {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         csvtk: \$(echo \$( csvtk version | sed -e 's/csvtk v//g' ))
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    out_extension = args.contains('--out-delimiter "\t"') || args.contains('-D "\t"') || args.contains("-D \$'\t'") ? "tsv" : "csv"
+    """
+    touch ${prefix}.${out_extension}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        csvtk: \$(echo \$( csvtk version | sed -e "s/csvtk v//g" ))
     END_VERSIONS
     """
 }

--- a/modules/nf-core/csvtk/split/tests/main.nf.test
+++ b/modules/nf-core/csvtk/split/tests/main.nf.test
@@ -1,0 +1,62 @@
+nextflow_process {
+
+    name "Test Process CSVTK_SPLIT"
+    script "../main.nf"
+    process "CSVTK_SPLIT"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "csvtk"
+    tag "csvtk/split"
+
+    test("split - csv") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [ file(params.modules_testdata_base_path + '/generic/tsv/test.tsv', checkIfExists: true) ]
+                ]
+                input[1] = "tsv"
+                input[2] = "tsv"
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("split - csv - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [ file(params.modules_testdata_base_path + '/generic/tsv/test.tsv', checkIfExists: true) ]
+                ]
+                input[1] = "tsv"
+                input[2] = "tsv"
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/csvtk/split/tests/main.nf.test.snap
+++ b/modules/nf-core/csvtk/split/tests/main.nf.test.snap
@@ -1,0 +1,72 @@
+{
+    "split - csv - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,b17a61b0c41b19f7df3740979d68a8a0"
+                ],
+                "split_csv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,b17a61b0c41b19f7df3740979d68a8a0"
+                ]
+            }
+        ],
+        "timestamp": "2024-05-22T10:02:46.053585"
+    },
+    "split - csv": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test-1.tsv:md5,2827284f1a6f41dd14ef82fb6a36ebad",
+                            "test-11.tsv:md5,6c5555d689c4e685d35d6e394ad6e1e6",
+                            "test-2.tsv:md5,589a2add7f0b8e998d4959e5d883e7d5",
+                            "test-4.tsv:md5,e51cd0bfc35f5353d1fb75f723772ed0",
+                            "test-NA.tsv:md5,20afd42832c6cf5821f9862d285c9350"
+                        ]
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,b17a61b0c41b19f7df3740979d68a8a0"
+                ],
+                "split_csv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test-1.tsv:md5,2827284f1a6f41dd14ef82fb6a36ebad",
+                            "test-11.tsv:md5,6c5555d689c4e685d35d6e394ad6e1e6",
+                            "test-2.tsv:md5,589a2add7f0b8e998d4959e5d883e7d5",
+                            "test-4.tsv:md5,e51cd0bfc35f5353d1fb75f723772ed0",
+                            "test-NA.tsv:md5,20afd42832c6cf5821f9862d285c9350"
+                        ]
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,b17a61b0c41b19f7df3740979d68a8a0"
+                ]
+            }
+        ],
+        "timestamp": "2024-05-22T10:02:35.8578"
+    }
+}

--- a/modules/nf-core/csvtk/split/tests/nextflow.config
+++ b/modules/nf-core/csvtk/split/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: CSVTK_SPLIT {
+        ext.args = "-C \'&\' --fields \'first_name\' "
+    }
+}

--- a/modules/nf-core/csvtk/split/tests/tags.yml
+++ b/modules/nf-core/csvtk/split/tests/tags.yml
@@ -1,0 +1,2 @@
+csvtk/split:
+  - "modules/nf-core/csvtk/split/**"

--- a/modules/nf-core/gawk/environment.yml
+++ b/modules/nf-core/gawk/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - anaconda::gawk=5.1.0
+  - conda-forge::gawk=5.3.0

--- a/modules/nf-core/gawk/main.nf
+++ b/modules/nf-core/gawk/main.nf
@@ -4,8 +4,8 @@ process GAWK {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gawk:5.1.0' :
-        'biocontainers/gawk:5.1.0' }"
+        'https://depot.galaxyproject.org/singularity/gawk:5.3.0' :
+        'biocontainers/gawk:5.3.0' }"
 
     input:
     tuple val(meta), path(input)

--- a/modules/nf-core/gawk/tests/main.nf.test.snap
+++ b/modules/nf-core/gawk/tests/main.nf.test.snap
@@ -11,7 +11,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,4c320d8c98ca80690afd7651da1ba520"
+                    "versions.yml:md5,842acc9870dc8ac280954047cb2aa23a"
                 ],
                 "output": [
                     [
@@ -22,15 +22,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,4c320d8c98ca80690afd7651da1ba520"
+                    "versions.yml:md5,842acc9870dc8ac280954047cb2aa23a"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "24.02.0"
+            "nextflow": "24.03.0"
         },
-        "timestamp": "2024-04-05T11:00:28.097563"
+        "timestamp": "2024-05-17T15:20:02.495430346"
     },
     "convert fasta to bed": {
         "content": [
@@ -44,7 +44,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,4c320d8c98ca80690afd7651da1ba520"
+                    "versions.yml:md5,842acc9870dc8ac280954047cb2aa23a"
                 ],
                 "output": [
                     [
@@ -55,14 +55,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,4c320d8c98ca80690afd7651da1ba520"
+                    "versions.yml:md5,842acc9870dc8ac280954047cb2aa23a"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "24.02.0"
+            "nextflow": "24.03.0"
         },
-        "timestamp": "2024-04-05T10:28:15.625869"
+        "timestamp": "2024-05-17T15:19:53.291809648"
     }
 }

--- a/modules/nf-core/segemehl/align/main.nf
+++ b/modules/nf-core/segemehl/align/main.nf
@@ -13,8 +13,11 @@ process SEGEMEHL_ALIGN {
     path(index)
 
     output:
-    tuple val(meta), path("${prefix}/*"), emit: results
-    path "versions.yml"                  , emit: versions
+    tuple val(meta), path("${prefix}/${prefix}.${suffix}"), emit: alignment
+    tuple val(meta), path("${prefix}/${prefix}.trns.txt") , emit: trans_alignments, optional: true
+    tuple val(meta), path("${prefix}/${prefix}.mult.bed") , emit: multi_bed, optional: true
+    tuple val(meta), path("${prefix}/${prefix}.sngl.bed") , emit: single_bed, optional: true
+    path "versions.yml"                                   , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -23,7 +26,7 @@ process SEGEMEHL_ALIGN {
     def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
     def reads = meta.single_end ? "-q ${reads}" : "-q ${reads[0]} -p ${reads[1]}"
-    def suffix = ( args.contains("-b") || args.contains("--bamabafixoida") ) ? "bam" : "sam"
+    suffix = ( args.contains("-b") || args.contains("--bamabafixoida") ) ? "bam" : "sam"
     """
     mkdir -p $prefix
 
@@ -43,7 +46,7 @@ process SEGEMEHL_ALIGN {
 
     stub:
     prefix = task.ext.prefix ?: "${meta.id}"
-    def suffix = ( args.contains("-b") || args.contains("--bamabafixoida") ) ? "bam" : "sam"
+    suffix = ( args.contains("-b") || args.contains("--bamabafixoida") ) ? "bam" : "sam"
     """
     mkdir -p $prefix
     touch ${prefix}/${prefix}.${suffix}

--- a/modules/nf-core/segemehl/align/meta.yml
+++ b/modules/nf-core/segemehl/align/meta.yml
@@ -11,7 +11,7 @@ tools:
       homepage: "https://www.bioinf.uni-leipzig.de/Software/segemehl/"
       documentation: "https://www.bioinf.uni-leipzig.de/Software/segemehl/"
       doi: "10.1186/gb-2014-15-2-r34"
-      licence: "GPL v3"
+      licence: ["GPL v3"]
 input:
   - meta:
       type: map
@@ -36,19 +36,38 @@ output:
       description: |
         Groovy Map containing sample information
         e.g. [ id:'test', single_end:false ]
-  - results:
-      type: directory
+  - alignment:
+      type: file
       description: |
-        Directory containing genomic alignments in SAM format
+        File containing genomic alignments in SAM format
           (please add "-b" flag to task.ext.args for BAM)
-        In addition to split-read alignments files when -S parameter used.
-          [ *.{sam,bam}, *.trns.txt, *.mult.bed, *.sngl.bed ]
-      pattern: "${meta.id}*"
+      pattern: "*.{sam,bam}"
+  - trans_alignments:
+      type: file
+      description: |
+        Custom text file containing all single split alignments predicted to be in trans
+          (optional, only if -S flag is set in task.ext.args)
+      pattern: "*.trns.txt"
+  - single_bed:
+      type: file
+      description: |
+        Bed file containing all single splice events predicted
+        in the split read alignments.
+          (optional, only if -S flag is set in task.ext.args)
+      pattern: "*.sngl.bed"
+  - multi_bed:
+      type: file
+      description: |
+        Bed file containing all splice events predicted
+        in the split read alignments.
+          (optional, only if -S flag is set in task.ext.args)
+      pattern: "*.mult.bed"
   - versions:
       type: file
       description: File containing software versions
       pattern: "versions.yml"
 authors:
   - "@BarryDigby"
+  - "@nictru"
 maintainers:
-  - "@BarryDigby"
+  - "@nictru"

--- a/modules/nf-core/segemehl/align/tests/main.nf.test
+++ b/modules/nf-core/segemehl/align/tests/main.nf.test
@@ -1,0 +1,140 @@
+nextflow_process {
+
+    name "Test Process SEGEMEHL_ALIGN"
+    script "../main.nf"
+    process "SEGEMEHL_ALIGN"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "segemehl"
+    tag "segemehl/align"
+    tag "segemehl/index"
+
+    setup {
+        run("SEGEMEHL_INDEX") {
+            script "../../../segemehl/index/main.nf"
+            process {
+                """
+                input[0] = Channel.of([
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                ])
+                """
+            }
+        }
+    }
+
+    test("homo_sapiens - single_end") {
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true) ]
+                ])
+                input[1] = Channel.of([
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[2] = SEGEMEHL_INDEX.out.index
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.alignment[0][1]).exists() },
+                { assert snapshot(process.out.versions).match("homo_sapiens - single_end - versions") }
+            )
+        }
+    }
+
+    test("homo_sapiens - paired_end") {
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true)
+                    ]
+                ])
+                input[1] = Channel.of([
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[2] = SEGEMEHL_INDEX.out.index
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.alignment[0][1]).exists() },
+                { assert snapshot(process.out.versions).match("homo_sapiens - paired_end - versions") }
+            )
+        }
+    }
+
+    test("homo_sapiens - split - single_end") {
+        config "./split.config"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true) ]
+                ])
+                input[1] = Channel.of([
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[2] = SEGEMEHL_INDEX.out.index
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.alignment[0][1]).exists() },
+                { assert path(process.out.trans_alignments[0][1]).exists() },
+                { assert path(process.out.multi_bed[0][1]).exists() },
+                { assert path(process.out.single_bed[0][1]).exists() },
+                { assert snapshot(process.out.versions).match("homo_sapiens - split - single_end - versions") }
+            )
+        }
+    }
+
+    test("homo_sapiens - split - paired_end") {
+        config "./split.config"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true)
+                    ]
+                ])
+                input[1] = Channel.of([
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[2] = SEGEMEHL_INDEX.out.index
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.alignment[0][1]).exists() },
+                { assert path(process.out.trans_alignments[0][1]).exists() },
+                { assert path(process.out.multi_bed[0][1]).exists() },
+                { assert path(process.out.single_bed[0][1]).exists() },
+                { assert snapshot(process.out.versions).match("homo_sapiens - split - paired_end - versions") }
+            )
+        }
+    }
+}

--- a/modules/nf-core/segemehl/align/tests/main.nf.test.snap
+++ b/modules/nf-core/segemehl/align/tests/main.nf.test.snap
@@ -1,0 +1,50 @@
+{
+    "homo_sapiens - paired_end - versions": {
+        "content": [
+            [
+                "versions.yml:md5,0c6afcd6ae65e27a0ea87f5b42c853eb"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-05-30T12:58:05.434115758"
+    },
+    "homo_sapiens - single_end - versions": {
+        "content": [
+            [
+                "versions.yml:md5,0c6afcd6ae65e27a0ea87f5b42c853eb"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-05-30T12:57:56.488707635"
+    },
+    "homo_sapiens - split - single_end - versions": {
+        "content": [
+            [
+                "versions.yml:md5,0c6afcd6ae65e27a0ea87f5b42c853eb"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-05-30T13:06:11.217385877"
+    },
+    "homo_sapiens - split - paired_end - versions": {
+        "content": [
+            [
+                "versions.yml:md5,0c6afcd6ae65e27a0ea87f5b42c853eb"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-05-30T13:06:29.757385118"
+    }
+}

--- a/modules/nf-core/segemehl/align/tests/split.config
+++ b/modules/nf-core/segemehl/align/tests/split.config
@@ -1,0 +1,5 @@
+process{
+    withName: SEGEMEHL_ALIGN {
+        ext.args = "-S"
+    }
+}

--- a/modules/nf-core/segemehl/align/tests/tags.yml
+++ b/modules/nf-core/segemehl/align/tests/tags.yml
@@ -1,0 +1,2 @@
+segemehl/align:
+  - modules/nf-core/segemehl/align/**

--- a/modules/nf-core/tximeta/tximport/templates/tximport.r
+++ b/modules/nf-core/tximeta/tximport/templates/tximport.r
@@ -169,9 +169,7 @@ if ("tx2gene" %in% names(transcript_info) && !is.null(transcript_info\$tx2gene))
         list(obj = gse, slot = "length", suffix = "gene_lengths.tsv"),
         list(obj = gse, slot = "abundance", suffix = "gene_tpm.tsv"),
         list(obj = gse, slot = "counts", suffix = "gene_counts.tsv"),
-        list(obj = gse.ls, slot = "abundance", suffix = "gene_tpm_length_scaled.tsv"),
         list(obj = gse.ls, slot = "counts", suffix = "gene_counts_length_scaled.tsv"),
-        list(obj = gse.s, slot = "abundance", suffix = "gene_tpm_scaled.tsv"),
         list(obj = gse.s, slot = "counts", suffix = "gene_counts_scaled.tsv")
     ))
 }

--- a/modules/nf-core/tximeta/tximport/tests/main.nf.test.snap
+++ b/modules/nf-core/tximeta/tximport/tests/main.nf.test.snap
@@ -14,7 +14,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:54.169267"
+        "timestamp": "2024-05-28T12:35:50.683744"
     },
     "lengths_gene_kallisto - stub": {
         "content": [
@@ -31,7 +31,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:20.838048"
+        "timestamp": "2024-05-28T12:35:16.126128"
     },
     "counts_gene_scaled_salmon - stub": {
         "content": [
@@ -48,7 +48,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:54.139493"
+        "timestamp": "2024-05-28T12:35:50.654405"
     },
     "counts_gene_kallisto - stub": {
         "content": [
@@ -65,7 +65,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:20.823542"
+        "timestamp": "2024-05-28T12:35:16.112898"
     },
     "lengths_transcript_salmon - stub": {
         "content": [
@@ -82,7 +82,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:54.157265"
+        "timestamp": "2024-05-28T12:35:50.67148"
     },
     "versions_salmon - stub": {
         "content": [
@@ -94,7 +94,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:54.175019"
+        "timestamp": "2024-05-28T12:35:50.690592"
     },
     "counts_gene_length_scaled_kallisto": {
         "content": [
@@ -111,7 +111,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:04.116135"
+        "timestamp": "2024-05-28T12:34:59.621599"
     },
     "lengths_transcript_salmon": {
         "content": [
@@ -128,7 +128,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:37.664041"
+        "timestamp": "2024-05-28T12:35:32.876208"
     },
     "counts_transcript_kallisto": {
         "content": [
@@ -145,7 +145,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:04.162273"
+        "timestamp": "2024-05-28T12:34:59.62725"
     },
     "counts_transcript_kallisto - stub": {
         "content": [
@@ -162,7 +162,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:20.834743"
+        "timestamp": "2024-05-28T12:35:16.122852"
     },
     "counts_transcript_salmon": {
         "content": [
@@ -179,7 +179,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:37.652813"
+        "timestamp": "2024-05-28T12:35:32.866731"
     },
     "lengths_gene_salmon - stub": {
         "content": [
@@ -196,7 +196,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:54.151603"
+        "timestamp": "2024-05-28T12:35:50.6654"
     },
     "tpm_gene_salmon": {
         "content": [
@@ -213,7 +213,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:37.669821"
+        "timestamp": "2024-05-28T12:35:32.881193"
     },
     "tpm_transcript_salmon": {
         "content": [
@@ -230,7 +230,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:37.674895"
+        "timestamp": "2024-05-28T12:35:32.886363"
     },
     "tpm_gene_salmon - stub": {
         "content": [
@@ -247,7 +247,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:54.163303"
+        "timestamp": "2024-05-28T12:35:50.677538"
     },
     "lengths_transcript_kallisto": {
         "content": [
@@ -264,7 +264,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:04.1686"
+        "timestamp": "2024-05-28T12:34:59.632822"
     },
     "counts_gene_length_scaled_kallisto - stub": {
         "content": [
@@ -281,7 +281,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:20.827742"
+        "timestamp": "2024-05-28T12:35:16.11652"
     },
     "tpm_gene_kallisto - stub": {
         "content": [
@@ -298,7 +298,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:20.846428"
+        "timestamp": "2024-05-28T12:35:16.133742"
     },
     "counts_transcript_salmon - stub": {
         "content": [
@@ -315,7 +315,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:54.145564"
+        "timestamp": "2024-05-28T12:35:50.660144"
     },
     "counts_gene_scaled_kallisto": {
         "content": [
@@ -332,7 +332,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:04.159638"
+        "timestamp": "2024-05-28T12:34:59.624732"
     },
     "counts_gene_salmon": {
         "content": [
@@ -349,7 +349,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:37.636972"
+        "timestamp": "2024-05-28T12:35:32.852188"
     },
     "versions_salmon": {
         "content": [
@@ -361,7 +361,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:37.680246"
+        "timestamp": "2024-05-28T12:35:32.892224"
     },
     "counts_gene_length_scaled_salmon": {
         "content": [
@@ -378,7 +378,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:37.642848"
+        "timestamp": "2024-05-28T12:35:32.857451"
     },
     "tpm_gene_kallisto": {
         "content": [
@@ -395,7 +395,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:04.172531"
+        "timestamp": "2024-05-28T12:34:59.636454"
     },
     "lengths_transcript_kallisto - stub": {
         "content": [
@@ -412,7 +412,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:20.842475"
+        "timestamp": "2024-05-28T12:35:16.129712"
     },
     "lengths_gene_kallisto": {
         "content": [
@@ -429,7 +429,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:04.16551"
+        "timestamp": "2024-05-28T12:34:59.630042"
     },
     "counts_gene_scaled_kallisto - stub": {
         "content": [
@@ -446,7 +446,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:20.831518"
+        "timestamp": "2024-05-28T12:35:16.119638"
     },
     "tpm_transcript_kallisto": {
         "content": [
@@ -463,7 +463,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:04.177955"
+        "timestamp": "2024-05-28T12:34:59.639525"
     },
     "lengths_gene_salmon": {
         "content": [
@@ -480,7 +480,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:37.658624"
+        "timestamp": "2024-05-28T12:35:32.871162"
     },
     "counts_gene_length_scaled_salmon - stub": {
         "content": [
@@ -497,7 +497,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:54.13369"
+        "timestamp": "2024-05-28T12:35:50.605613"
     },
     "counts_gene_kallisto": {
         "content": [
@@ -514,7 +514,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:04.113216"
+        "timestamp": "2024-05-28T12:34:59.61832"
     },
     "versions_kallisto": {
         "content": [
@@ -526,7 +526,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:04.181904"
+        "timestamp": "2024-05-28T12:34:59.642751"
     },
     "counts_gene_salmon - stub": {
         "content": [
@@ -543,7 +543,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:54.127272"
+        "timestamp": "2024-05-28T12:35:50.598457"
     },
     "versions_kallisto - stub": {
         "content": [
@@ -555,7 +555,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:20.86053"
+        "timestamp": "2024-05-28T12:35:16.141689"
     },
     "tpm_transcript_kallisto - stub": {
         "content": [
@@ -572,7 +572,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:20.856075"
+        "timestamp": "2024-05-28T12:35:16.137716"
     },
     "counts_gene_scaled_salmon": {
         "content": [
@@ -589,6 +589,6 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-11T11:35:37.647691"
+        "timestamp": "2024-05-28T12:35:32.862272"
     }
 }

--- a/subworkflows/local/discovery/segemehl.nf
+++ b/subworkflows/local/discovery/segemehl.nf
@@ -14,8 +14,8 @@ workflow SEGEMEHL {
 
     index = index ?: INDEX( fasta ).index
     ALIGN( reads, fasta, index )
-    UNIFY( ALIGN.out.results
-        .map{ meta, results ->  [ meta + [tool: "segemehl"], results ] }, [] )
+    UNIFY( ALIGN.out.single_bed
+        .map{ meta, bed ->  [ meta + [tool: "segemehl"], bed ] }, [] )
 
     ch_versions = ch_versions.mix(ALIGN.out.versions)
     ch_versions = ch_versions.mix(UNIFY.out.versions)


### PR DESCRIPTION
#122 introduced a bug with segemehl. The `SEGEMEHL_ALIGN` process originally had a single output channel containing a list of all output files. This was manageable before #122 because a specific process called `SEGEMEHL_FILTER` handled this list. In #122, we switched to the nf-core `GAWK` module for unification (and common filtering of the unified files afterward). 
The `GAWK`/`UNIFY` module then used all files from the list output of `SEGEMEHL_ALIGN` as input. This was problematic since not all files followed the expected input format; thus, the output of `UNIFY` was partially binary.

The `SEGEMEHL_ALIGN` process was updated via a [modules PR](https://github.com/nf-core/modules/pull/5724).
This PR integrates this update into the pipeline (other nf-core modules were also updated).