### PR TITLE
Add support for ext.args in ciriquant

### DIFF
--- a/modules/local/ciriquant/main.nf
+++ b/modules/local/ciriquant/main.nf
@@ -47,7 +47,8 @@ process CIRIQUANT {
         --config config.yml \\
         --no-gene \\
         -o ${prefix} \\
-        -p ${prefix}
+        -p ${prefix} \\
+        ${args}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
Just a tiny change, enables correct handling of `ext.args` for ciriquant