### PR TITLE
Implement circrna database annotation functionalities

### DIFF
--- a/assets/schema_annotation.json
+++ b/assets/schema_annotation.json
@@ -10,7 +10,8 @@
             "name": {
                 "type": "string",
                 "pattern": "^\\S+$",
-                "errorMessage": "Annotation file name must be provided and cannot contain spaces"
+                "errorMessage": "Annotation file name must be provided and cannot contain spaces",
+                "meta": ["id"]
             },
             "file": {
                 "type": "string",
@@ -24,7 +25,8 @@
                 "minimum": 0,
                 "maximum": 1,
                 "default": 0.9,
-                "errorMessage": "Minimum overlap must be a number between 0 and 1"
+                "errorMessage": "Minimum overlap must be a number between 0 and 1",
+                "meta": ["min_overlap"]
             }
         },
         "required": ["name", "file"]

--- a/assets/schema_annotation.json
+++ b/assets/schema_annotation.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://raw.githubusercontent.com/nf-core/circrna/master/assets/schema_annotation.json",
+    "title": "nf-core/circrna pipeline - params.annotation schema",
+    "description": "Schema for the file provided with params.annotation",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "pattern": "^\\S+$",
+                "errorMessage": "Annotation file name must be provided and cannot contain spaces"
+            },
+            "file": {
+                "type": "string",
+                "format": "file-path",
+                "exists": true,
+                "pattern": "^\\S+\\.bed$",
+                "errorMessage": "Annotation file must be provided and must be a BED file"
+            },
+            "min_overlap": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.9,
+                "errorMessage": "Minimum overlap must be a number between 0 and 1"
+            }
+        },
+        "required": ["name", "file"]
+    }
+}

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -576,18 +576,24 @@ process {
     }
 
     withName: '.*:ANNOTATION:INGEST_DATABASE_NAMES' {
-        ext.args = { "-v FS='\\t' -v OFS='\\t' '{ print \$1, \$2, \$3, \"${meta.id}:\" + \$4, \$5, \$6 }'" }
+        ext.args = { "-v FS='\\t' -v OFS='\\t' '{ print \$1, \$2, \$3, \"${meta.id}:\" \$4, \$5, \$6 }'" }
         ext.suffix = "named.bed"
     }
 
     withName: '.*:ANNOTATION:DATABASE_ANNOTATION' {
-        ext.args = { "-f ${meta.min_overlap} -r -loj" }
+        ext.args = { "-f ${meta.min_overlap} -r -loj -wa -wb" }
         ext.suffix = "annotated.bed"
+    }
+
+    withName: '.*:ANNOTATION:CLEAN_DATABASE_ANNOTATION' {
+        // Keep first 10 columns and the 14th column
+        ext.args = "-v FS='\\t' -v OFS='\\t' '{ print \$1, \$2, \$3, \$4, \$5, \$6, \$7, \$8, \$9, \$10, \$14 }'"
+        ext.suffix = "cleaned_db.bed"
     }
 
     withName: '.*:ANNOTATION:COMBINE_DATABASES' {
         ext.args = "-k 1,1 -k2,2n -k3,3n -u"
-        ext.suffix = "combined.bed"
+        ext.suffix = "combined_dbs.bed"
     }
 
     withName: '.*:ANNOTATION:COMBINE_BEDS' {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -570,7 +570,7 @@ process {
         ext.when = { params.tool.split(',').length > 1 }
     }
 
-    withName: '.*:ANNOTATION:INTERSECT' {
+    withName: '.*:ANNOTATION:INTERSECT_GTF' {
         ext.args = "-loj"
         ext.suffix = "intersect.bed"
     }
@@ -580,20 +580,9 @@ process {
         ext.suffix = "named.bed"
     }
 
-    withName: '.*:ANNOTATION:DATABASE_ANNOTATION' {
+    withName: '.*:ANNOTATION:INTERSECT_DATABASE' {
         ext.args = { "-f ${meta.min_overlap} -r -loj -wa -wb" }
         ext.suffix = "annotated.bed"
-    }
-
-    withName: '.*:ANNOTATION:CLEAN_DATABASE_ANNOTATION' {
-        // Keep first 10 columns and the 14th column
-        ext.args = "-v FS='\\t' -v OFS='\\t' '{ print \$1, \$2, \$3, \$4, \$5, \$6, \$7, \$8, \$9, \$10, \$14 }'"
-        ext.suffix = "cleaned_db.bed"
-    }
-
-    withName: '.*:ANNOTATION:COMBINE_DATABASES' {
-        ext.args = "-k 1,1 -k2,2n -k3,3n -u"
-        ext.suffix = "combined_dbs.bed"
     }
 
     withName: '.*:ANNOTATION:COMBINE_BEDS' {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -596,7 +596,7 @@ process {
     }
 
     withName: '.*:ANNOTATION:REMOVE_SCORE_STRAND' {
-        ext.args = "-v FS='\\t' -v OFS='\\t' '{ print \$1, \$2, \$3, \$1 \":\" \$2 \"-\" \$3, \".\", \".\", \$7, \$8, \$9, \$10 }'"
+        ext.args = "-v FS='\\t' -v OFS='\\t' '{ print \$1, \$2, \$3, \$1 \":\" \$2 \"-\" \$3, \".\", \".\", \$7, \$8, \$9, \$10, \$11 }'"
         ext.suffix = "tidy.bed"
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -575,6 +575,21 @@ process {
         ext.suffix = "intersect.bed"
     }
 
+    withName: '.*:ANNOTATION:INGEST_DATABASE_NAMES' {
+        ext.args = { "-v FS='\\t' -v OFS='\\t' '{ print \$1, \$2, \$3, \"${meta.id}:\" + \$4, \$5, \$6 }'" }
+        ext.suffix = "named.bed"
+    }
+
+    withName: '.*:ANNOTATION:DATABASE_ANNOTATION' {
+        ext.args = { "-f ${meta.min_overlap} -r -loj" }
+        ext.suffix = "annotated.bed"
+    }
+
+    withName: '.*:ANNOTATION:COMBINE_DATABASES' {
+        ext.args = "-k 1,1 -k2,2n -k3,3n -u"
+        ext.suffix = "combined.bed"
+    }
+
     withName: '.*:ANNOTATION:COMBINE_BEDS' {
         ext.args = "-k 1,1 -k2,2n -k3,3n -u"
         ext.suffix = "combined.bed"

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -562,15 +562,6 @@ process {
         ext.suffix = {"${meta.tool}.filtered.bed"}
     }
 
-    withName: ANNOTATION {
-        ext.prefix = { "${meta.id}.${meta.tool}.annotated" }
-        publishDir = [
-            path: { "${params.outdir}/circrna_discovery/${meta.tool}/${meta.id}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
-    }
-
     withName: UPSET_SAMPLES {
         ext.when = { params.tool.split(',').length > 1 }
     }

--- a/main.nf
+++ b/main.nf
@@ -61,7 +61,7 @@ workflow NFCORE_CIRCRNA {
     ch_mature      = params.mature ? Channel.value([[id: "mature"], file(params.mature, checkIfExists:true)]) : Channel.empty()
     ch_phenotype   = params.phenotype ? Channel.value([[id: "phenotype"], file(params.phenotype, checkIfExists:true)]) : Channel.empty()
     ch_species     = params.phenotype ? Channel.value(params.species_id) : Channel.empty()
-    ch_annotations = params.annotations ? Channel.fromSamplesheet("annotations") : Channel.empty()
+    ch_annotation  = params.annotation ? Channel.fromSamplesheet("annotation") : Channel.empty()
 
     CIRCRNA (
         ch_samplesheet,
@@ -69,7 +69,7 @@ workflow NFCORE_CIRCRNA {
         ch_fasta,
         ch_gtf,
         ch_mature,
-        ch_annotations,
+        ch_annotation,
         ch_species,
         ch_versions
     )

--- a/main.nf
+++ b/main.nf
@@ -61,7 +61,7 @@ workflow NFCORE_CIRCRNA {
     ch_mature      = params.mature ? Channel.value([[id: "mature"], file(params.mature, checkIfExists:true)]) : Channel.empty()
     ch_phenotype   = params.phenotype ? Channel.value([[id: "phenotype"], file(params.phenotype, checkIfExists:true)]) : Channel.empty()
     ch_species     = params.phenotype ? Channel.value(params.species_id) : Channel.empty()
-    ch_annotations = Channel.fromSamplesheet("annotations")
+    ch_annotations = params.annotations ? Channel.fromSamplesheet("annotations") : Channel.empty()
 
     CIRCRNA (
         ch_samplesheet,

--- a/main.nf
+++ b/main.nf
@@ -61,6 +61,7 @@ workflow NFCORE_CIRCRNA {
     ch_mature      = params.mature ? Channel.value([[id: "mature"], file(params.mature, checkIfExists:true)]) : Channel.empty()
     ch_phenotype   = params.phenotype ? Channel.value([[id: "phenotype"], file(params.phenotype, checkIfExists:true)]) : Channel.empty()
     ch_species     = params.phenotype ? Channel.value(params.species_id) : Channel.empty()
+    ch_annotations = Channel.fromSamplesheet("annotations")
 
     CIRCRNA (
         ch_samplesheet,
@@ -68,6 +69,7 @@ workflow NFCORE_CIRCRNA {
         ch_fasta,
         ch_gtf,
         ch_mature,
+        ch_annotations,
         ch_species,
         ch_versions
     )

--- a/modules/local/annotation/main.nf
+++ b/modules/local/annotation/main.nf
@@ -8,7 +8,7 @@ process ANNOTATION {
         'biocontainers/pandas:1.5.2' }"
 
     input:
-    tuple val(meta), path(intersection)
+    tuple val(meta), path(gtf_intersection), path(db_intersections)
     val(exon_boundary)
 
     output:

--- a/modules/local/annotation/templates/annotation.py
+++ b/modules/local/annotation/templates/annotation.py
@@ -107,6 +107,17 @@ df_intergenic = df_intergenic[bed_order]
 
 df = pd.concat([df, df_intergenic], axis=0)
 
+db_colnames = ['chr', 'start', 'end', 'name', 'score', 'strand', 'db_chr', 'db_start', 'db_end', 'db_name', 'db_score', 'db_strand']
+db_usecols = ['chr', 'start', 'end', 'name', 'score', 'strand', 'db_name']
+df_databases = pd.concat([pd.read_csv(db_path, sep="\\t", header=0, names=db_colnames, usecols=db_usecols) for db_path in "${db_intersections}".split()])
+
+# Group by chr, start, end, name, score, strand, and aggregate the db_name to csv string
+df_databases = df_databases.groupby(['chr', 'start', 'end', 'name', 'score', 'strand']).aggregate({
+    'db_name': lambda x: ",".join(x) if len(x) > 0 else "."
+})
+
+df = df.merge(df_databases, how='left', on=['chr', 'start', 'end', 'name', 'score', 'strand'])
+
 # Sort by chr, start, end
 df = df.sort_values(['chr', 'start', 'end'])
 

--- a/modules/local/annotation/templates/annotation.py
+++ b/modules/local/annotation/templates/annotation.py
@@ -109,7 +109,7 @@ df = pd.concat([df, df_intergenic], axis=0)
 
 db_colnames = ['chr', 'start', 'end', 'name', 'score', 'strand', 'db_chr', 'db_start', 'db_end', 'db_name', 'db_score', 'db_strand']
 db_usecols = ['chr', 'start', 'end', 'name', 'score', 'strand', 'db_name']
-df_databases = pd.concat([pd.read_csv(db_path, sep="\\t", header=0, names=db_colnames, usecols=db_usecols) for db_path in "${db_intersections}".split()])
+df_databases = pd.concat([pd.read_csv(db_path, sep="\\t", names=db_colnames, usecols=db_usecols) for db_path in "${db_intersections}".split()])
 
 # Group by chr, start, end, name, score, strand, and aggregate the db_name to csv string
 df_databases = df_databases.groupby(['chr', 'start', 'end', 'name', 'score', 'strand']).aggregate({

--- a/modules/local/annotation/templates/annotation.py
+++ b/modules/local/annotation/templates/annotation.py
@@ -41,7 +41,7 @@ attributes = ['gene_id', 'gene_name', 'transcript_id']
 
 exon_boundary = int("${exon_boundary}")
 
-df = pd.read_csv("${intersection}", sep="\\t", header=None, usecols=columns.keys())
+df = pd.read_csv("${gtf_intersection}", sep="\\t", header=None, usecols=columns.keys())
 df = df.rename(columns=columns)
 
 # Extract circRNAs without match

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,6 +13,7 @@ params {
     input                      = null
     outdir                     = null
     phenotype                  = null
+    annotation                 = null
 
     // workflow options
     tool                       = 'circexplorer2'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -40,6 +40,17 @@
                     "description": "Phenotype CSV file specifying the experimental design. If provided, the pipeline will run CIRCTEST.",
                     "help_text": "There are two rules for providing the phenotype CSV file. 1) The 'sample' column must match the sample sheets 'sample' column. 2) The response variable containing the phenotype of primary interest in the experiment must have the column name condition.  All other columns included in the file are controlled for in the `DESeq2` design. \n\n| sample    \t| condition \t| replicate \t|\n|-----------\t|-----------\t|-----------\t|\n| control_1 \t| ctr       \t| 1         \t|\n| control_2 \t| ctr       \t| 2         \t|\n| control_3 \t| ctr       \t| 3         \t|\n| treated_1 \t| trt       \t| 1         \t|\n| treated_2 \t| trt       \t| 2         \t|\n| treated_3 \t| trt       \t| 3         \t|\n\nThe above phenotype file will identify differentially expressed circRNAs/mRNAs between control and treatment cells, whilst controlling for the effect of variation between replicates: ` ~ replicates + condition`",
                     "fa_icon": "fas fa-file-csv"
+                },
+                "annotation": {
+                    "type": "string",
+                    "format": "file-path",
+                    "exists": true,
+                    "schema": "assets/schema_annotation.json",
+                    "mimetype": "text/csv",
+                    "pattern": "^\\S+\\.csv$",
+                    "description": "Path to a CSV file containing BED files that should be used for annotation.",
+                    "help_text": "The annotation file should be a CSV file with the following columns: `name`, `file` and `min_overlap`. The `name` column should contain a unique identifier for the annotation, the `file` column should contain the path to the BED file and the `min_overlap` column should contain the minimum overlap required for a circRNA to be considered as overlapping with the annotation. The `min_overlap` column is optional and defaults to 0.9 if not provided.",
+                    "fa_icon": "fas fa-file-csv"
                 }
             }
         },

--- a/subworkflows/local/circrna_discovery.nf
+++ b/subworkflows/local/circrna_discovery.nf
@@ -30,6 +30,7 @@ workflow CIRCRNA_DISCOVERY {
     chromosomes
     hisat2_index
     star_index
+    ch_annotations
     bsj_reads
     tool_filter
     duplicates_fun
@@ -140,7 +141,7 @@ workflow CIRCRNA_DISCOVERY {
     // ANNOTATION WORKFLOW:
     //
 
-    ANNOTATION( ch_bed_incl_merged, gtf, exon_boundary )
+    ANNOTATION( ch_bed_incl_merged, gtf, exon_boundary, ch_annotations )
     ch_versions = ch_versions.mix(ANNOTATION.out.versions)
 
     //

--- a/subworkflows/local/circrna_discovery.nf
+++ b/subworkflows/local/circrna_discovery.nf
@@ -30,7 +30,7 @@ workflow CIRCRNA_DISCOVERY {
     chromosomes
     hisat2_index
     star_index
-    ch_annotations
+    ch_annotation
     bsj_reads
     tool_filter
     duplicates_fun
@@ -141,7 +141,7 @@ workflow CIRCRNA_DISCOVERY {
     // ANNOTATION WORKFLOW:
     //
 
-    ANNOTATION( ch_bed_incl_merged, gtf, exon_boundary, ch_annotations )
+    ANNOTATION( ch_bed_incl_merged, gtf, exon_boundary, ch_annotation )
     ch_versions = ch_versions.mix(ANNOTATION.out.versions)
 
     //

--- a/subworkflows/local/discovery/annotation.nf
+++ b/subworkflows/local/discovery/annotation.nf
@@ -1,8 +1,11 @@
-include { BEDTOOLS_INTERSECT as INTERSECT } from '../../../modules/nf-core/bedtools/intersect'
-include { ANNOTATION as GTF_ANNOTATION    } from '../../../modules/local/annotation'
-include { GNU_SORT as COMBINE_BEDS        } from '../../../modules/nf-core/gnu/sort'
-include { GAWK as REMOVE_SCORE_STRAND     } from '../../../modules/nf-core/gawk'
-include { GNU_SORT as COMBINE_GTFS        } from '../../../modules/nf-core/gnu/sort'
+include { BEDTOOLS_INTERSECT as INTERSECT           } from '../../../modules/nf-core/bedtools/intersect'
+include { ANNOTATION as GTF_ANNOTATION              } from '../../../modules/local/annotation'
+include { GAWK as INGEST_DATABASE_NAMES             } from '../../../modules/nf-core/gawk'
+include { GNU_SORT as COMBINE_DATABASES             } from '../../../modules/nf-core/gnu/sort'
+include { BEDTOOLS_INTERSECT as DATABASE_ANNOTATION } from '../../../modules/nf-core/bedtools/intersect'
+include { GNU_SORT as COMBINE_BEDS                  } from '../../../modules/nf-core/gnu/sort'
+include { GAWK as REMOVE_SCORE_STRAND               } from '../../../modules/nf-core/gawk'
+include { GNU_SORT as COMBINE_GTFS                  } from '../../../modules/nf-core/gnu/sort'
 
 workflow ANNOTATION {
     take:
@@ -14,13 +17,23 @@ workflow ANNOTATION {
     main:
     ch_versions = Channel.empty()
 
-    INTERSECT( regions.combine(gtf), [[], []])
+    INTERSECT( regions.combine(gtf), [[], []] )
     GTF_ANNOTATION( INTERSECT.out.intersect, exon_boundary )
-
-    ch_annotation.view()
 
     ch_bed_merged = GTF_ANNOTATION.out.bed.filter{ meta, bed -> meta.tool == "merged" }
     ch_gtf_merged = GTF_ANNOTATION.out.gtf.filter{ meta, gtf -> meta.tool == "merged" }
+
+    INGEST_DATABASE_NAMES( ch_annotation, [] )
+    DATABASE_ANNOTATION( ch_bed_merged.combine(INGEST_DATABASE_NAMES.out.output)
+        .map{ meta1, regions, meta2, database ->
+            [meta1 + [id: "${meta1.id}:${meta2.id}",
+                sample: meta1.id,
+                db: meta2.id,
+                min_overlap: meta2.min_overlap], regions, database] },
+        [[], []])
+    COMBINE_DATABASES( DATABASE_ANNOTATION.out.intersect
+        .map{ meta, annotated -> [[id: meta.sample], annotated] }
+        .groupTuple())
 
     COMBINE_BEDS(ch_bed_merged.map{ meta, bed -> bed}.collect().map{[[id: "annotation"], it]})
     REMOVE_SCORE_STRAND( COMBINE_BEDS.out.sorted, [])
@@ -28,6 +41,9 @@ workflow ANNOTATION {
 
     ch_versions = ch_versions.mix(INTERSECT.out.versions)
     ch_versions = ch_versions.mix(GTF_ANNOTATION.out.versions)
+    ch_versions = ch_versions.mix(INGEST_DATABASE_NAMES.out.versions)
+    ch_versions = ch_versions.mix(COMBINE_DATABASES.out.versions)
+    ch_versions = ch_versions.mix(DATABASE_ANNOTATION.out.versions)
     ch_versions = ch_versions.mix(COMBINE_BEDS.out.versions)
     ch_versions = ch_versions.mix(REMOVE_SCORE_STRAND.out.versions)
     ch_versions = ch_versions.mix(COMBINE_GTFS.out.versions)

--- a/subworkflows/local/discovery/annotation.nf
+++ b/subworkflows/local/discovery/annotation.nf
@@ -1,8 +1,8 @@
-include { BEDTOOLS_INTERSECT as INTERSECT           } from '../../../modules/nf-core/bedtools/intersect'
-include { ANNOTATION as GTF_ANNOTATION              } from '../../../modules/local/annotation'
+include { BEDTOOLS_INTERSECT as INTERSECT_GTF       } from '../../../modules/nf-core/bedtools/intersect'
+include { ANNOTATION as ANNOTATE                    } from '../../../modules/local/annotation'
 include { GAWK as INGEST_DATABASE_NAMES             } from '../../../modules/nf-core/gawk'
 include { GNU_SORT as COMBINE_DATABASES             } from '../../../modules/nf-core/gnu/sort'
-include { BEDTOOLS_INTERSECT as DATABASE_ANNOTATION } from '../../../modules/nf-core/bedtools/intersect'
+include { BEDTOOLS_INTERSECT as INTERSECT_DATABASE  } from '../../../modules/nf-core/bedtools/intersect'
 include { GAWK as CLEAN_DATABASE_ANNOTATION         } from '../../../modules/nf-core/gawk'
 include { GNU_SORT as COMBINE_BEDS                  } from '../../../modules/nf-core/gnu/sort'
 include { GAWK as REMOVE_SCORE_STRAND               } from '../../../modules/nf-core/gawk'
@@ -18,34 +18,32 @@ workflow ANNOTATION {
     main:
     ch_versions = Channel.empty()
 
-    INTERSECT( regions.combine(gtf), [[], []] )
-    GTF_ANNOTATION( INTERSECT.out.intersect, exon_boundary )
-
-    ch_bed_merged = GTF_ANNOTATION.out.bed.filter{ meta, bed -> meta.tool == "merged" }
-    ch_gtf_merged = GTF_ANNOTATION.out.gtf.filter{ meta, gtf -> meta.tool == "merged" }
-
+    INTERSECT_GTF( regions.combine(gtf), [[], []] )
     INGEST_DATABASE_NAMES( ch_annotation, [] )
-    DATABASE_ANNOTATION( ch_bed_merged.combine(INGEST_DATABASE_NAMES.out.output)
+    INTERSECT_DATABASE( regions.combine(INGEST_DATABASE_NAMES.out.output)
         .map{ meta1, regions, meta2, database ->
-            [meta1 + [id: "${meta1.id}:${meta2.id}",
-                sample: meta1.id,
-                db: meta2.id,
+            [[id: "${meta1.id}:${meta2.id}",
+                original_meta: meta1,
                 min_overlap: meta2.min_overlap], regions, database] },
         [[], []])
-    CLEAN_DATABASE_ANNOTATION( DATABASE_ANNOTATION.out.intersect, [] )
-    COMBINE_DATABASES( CLEAN_DATABASE_ANNOTATION.out.output
-        .map{ meta, annotated -> [[id: meta.sample], annotated] }
-        .groupTuple())
+
+    ANNOTATE( INTERSECT_GTF.out.intersect
+        .join(INTERSECT_DATABASE.out.intersect
+            .map{ meta, bed -> [meta.original_meta, bed] }
+            .groupTuple()),
+        exon_boundary )
+
+    ch_bed_merged = ANNOTATE.out.bed.filter{ meta, bed -> meta.tool == "merged" }
+    ch_gtf_merged = ANNOTATE.out.gtf.filter{ meta, gtf -> meta.tool == "merged" }
 
     COMBINE_BEDS(ch_bed_merged.map{ meta, bed -> bed}.collect().map{[[id: "annotation"], it]})
     REMOVE_SCORE_STRAND( COMBINE_BEDS.out.sorted, [])
     COMBINE_GTFS(ch_gtf_merged.map{ meta, gtf -> gtf}.collect().map{[[id: "annotation"], it]})
 
-    ch_versions = ch_versions.mix(INTERSECT.out.versions)
-    ch_versions = ch_versions.mix(GTF_ANNOTATION.out.versions)
+    ch_versions = ch_versions.mix(INTERSECT_GTF.out.versions)
     ch_versions = ch_versions.mix(INGEST_DATABASE_NAMES.out.versions)
-    ch_versions = ch_versions.mix(COMBINE_DATABASES.out.versions)
-    ch_versions = ch_versions.mix(DATABASE_ANNOTATION.out.versions)
+    ch_versions = ch_versions.mix(INTERSECT_DATABASE.out.versions)
+    ch_versions = ch_versions.mix(ANNOTATE.out.versions)
     ch_versions = ch_versions.mix(COMBINE_BEDS.out.versions)
     ch_versions = ch_versions.mix(REMOVE_SCORE_STRAND.out.versions)
     ch_versions = ch_versions.mix(COMBINE_GTFS.out.versions)

--- a/subworkflows/local/discovery/annotation.nf
+++ b/subworkflows/local/discovery/annotation.nf
@@ -1,5 +1,5 @@
 include { BEDTOOLS_INTERSECT as INTERSECT } from '../../../modules/nf-core/bedtools/intersect'
-include { ANNOTATION as ANNOTATE          } from '../../../modules/local/annotation'
+include { ANNOTATION as GTF_ANNOTATION    } from '../../../modules/local/annotation'
 include { GNU_SORT as COMBINE_BEDS        } from '../../../modules/nf-core/gnu/sort'
 include { GAWK as REMOVE_SCORE_STRAND     } from '../../../modules/nf-core/gawk'
 include { GNU_SORT as COMBINE_GTFS        } from '../../../modules/nf-core/gnu/sort'
@@ -9,25 +9,25 @@ workflow ANNOTATION {
     regions
     gtf
     exon_boundary
-    ch_annotations
+    ch_annotation
 
     main:
     ch_versions = Channel.empty()
 
     INTERSECT( regions.combine(gtf), [[], []])
-    ANNOTATE( INTERSECT.out.intersect, exon_boundary )
+    GTF_ANNOTATION( INTERSECT.out.intersect, exon_boundary )
 
-    ch_annotations.view()
+    ch_annotation.view()
 
-    ch_bed_merged = ANNOTATE.out.bed.filter{ meta, bed -> meta.tool == "merged" }
-    ch_gtf_merged = ANNOTATE.out.gtf.filter{ meta, gtf -> meta.tool == "merged" }
+    ch_bed_merged = GTF_ANNOTATION.out.bed.filter{ meta, bed -> meta.tool == "merged" }
+    ch_gtf_merged = GTF_ANNOTATION.out.gtf.filter{ meta, gtf -> meta.tool == "merged" }
 
     COMBINE_BEDS(ch_bed_merged.map{ meta, bed -> bed}.collect().map{[[id: "annotation"], it]})
     REMOVE_SCORE_STRAND( COMBINE_BEDS.out.sorted, [])
     COMBINE_GTFS(ch_gtf_merged.map{ meta, gtf -> gtf}.collect().map{[[id: "annotation"], it]})
 
     ch_versions = ch_versions.mix(INTERSECT.out.versions)
-    ch_versions = ch_versions.mix(ANNOTATE.out.versions)
+    ch_versions = ch_versions.mix(GTF_ANNOTATION.out.versions)
     ch_versions = ch_versions.mix(COMBINE_BEDS.out.versions)
     ch_versions = ch_versions.mix(REMOVE_SCORE_STRAND.out.versions)
     ch_versions = ch_versions.mix(COMBINE_GTFS.out.versions)

--- a/subworkflows/local/discovery/annotation.nf
+++ b/subworkflows/local/discovery/annotation.nf
@@ -9,12 +9,15 @@ workflow ANNOTATION {
     regions
     gtf
     exon_boundary
+    ch_annotations
 
     main:
     ch_versions = Channel.empty()
 
     INTERSECT( regions.combine(gtf), [[], []])
     ANNOTATE( INTERSECT.out.intersect, exon_boundary )
+
+    ch_annotations.view()
 
     ch_bed_merged = ANNOTATE.out.bed.filter{ meta, bed -> meta.tool == "merged" }
     ch_gtf_merged = ANNOTATE.out.gtf.filter{ meta, gtf -> meta.tool == "merged" }

--- a/subworkflows/local/discovery/annotation.nf
+++ b/subworkflows/local/discovery/annotation.nf
@@ -30,7 +30,8 @@ workflow ANNOTATION {
     ANNOTATE( INTERSECT_GTF.out.intersect
         .join(INTERSECT_DATABASE.out.intersect
             .map{ meta, bed -> [meta.original_meta, bed] }
-            .groupTuple()),
+            .groupTuple(), remainder: true)
+        .map{ meta, gtf_intersection, db_intersections -> [meta, gtf_intersection, db_intersections ?: []]},
         exon_boundary )
 
     ch_bed_merged = ANNOTATE.out.bed.filter{ meta, bed -> meta.tool == "merged" }

--- a/subworkflows/local/discovery/annotation.nf
+++ b/subworkflows/local/discovery/annotation.nf
@@ -22,7 +22,7 @@ workflow ANNOTATION {
     INGEST_DATABASE_NAMES( ch_annotation, [] )
     INTERSECT_DATABASE( regions.combine(INGEST_DATABASE_NAMES.out.output)
         .map{ meta1, regions, meta2, database ->
-            [[id: "${meta1.id}:${meta2.id}",
+            [[id: "${meta1.id}-${meta2.id}",
                 original_meta: meta1,
                 min_overlap: meta2.min_overlap], regions, database] },
         [[], []])

--- a/subworkflows/local/discovery/annotation.nf
+++ b/subworkflows/local/discovery/annotation.nf
@@ -3,6 +3,7 @@ include { ANNOTATION as GTF_ANNOTATION              } from '../../../modules/loc
 include { GAWK as INGEST_DATABASE_NAMES             } from '../../../modules/nf-core/gawk'
 include { GNU_SORT as COMBINE_DATABASES             } from '../../../modules/nf-core/gnu/sort'
 include { BEDTOOLS_INTERSECT as DATABASE_ANNOTATION } from '../../../modules/nf-core/bedtools/intersect'
+include { GAWK as CLEAN_DATABASE_ANNOTATION         } from '../../../modules/nf-core/gawk'
 include { GNU_SORT as COMBINE_BEDS                  } from '../../../modules/nf-core/gnu/sort'
 include { GAWK as REMOVE_SCORE_STRAND               } from '../../../modules/nf-core/gawk'
 include { GNU_SORT as COMBINE_GTFS                  } from '../../../modules/nf-core/gnu/sort'
@@ -31,7 +32,8 @@ workflow ANNOTATION {
                 db: meta2.id,
                 min_overlap: meta2.min_overlap], regions, database] },
         [[], []])
-    COMBINE_DATABASES( DATABASE_ANNOTATION.out.intersect
+    CLEAN_DATABASE_ANNOTATION( DATABASE_ANNOTATION.out.intersect, [] )
+    COMBINE_DATABASES( CLEAN_DATABASE_ANNOTATION.out.output
         .map{ meta, annotated -> [[id: meta.sample], annotated] }
         .groupTuple())
 

--- a/workflows/circrna/main.nf
+++ b/workflows/circrna/main.nf
@@ -58,6 +58,7 @@ workflow CIRCRNA {
     ch_fasta
     ch_gtf
     ch_mature
+    ch_annotations
     ch_species
     ch_versions
 
@@ -143,6 +144,7 @@ workflow CIRCRNA {
         chromosomes,
         hisat2_index,
         star_index,
+        ch_annotations,
         params.bsj_reads,
         params.tool_filter,
         params.duplicates_fun,

--- a/workflows/circrna/main.nf
+++ b/workflows/circrna/main.nf
@@ -58,7 +58,7 @@ workflow CIRCRNA {
     ch_fasta
     ch_gtf
     ch_mature
-    ch_annotations
+    ch_annotation
     ch_species
     ch_versions
 
@@ -144,7 +144,7 @@ workflow CIRCRNA {
         chromosomes,
         hisat2_index,
         star_index,
-        ch_annotations,
+        ch_annotation,
         params.bsj_reads,
         params.tool_filter,
         params.duplicates_fun,


### PR DESCRIPTION
This PR adds a parameter `annotation` which accepts the path to an additional samplesheet. This samplesheet can contain an arbitrary number of bed files provided by the circrna databases (circbase, circatlas, circbank, ...). The found circRNA locations are then compared with the database regions and annotated if a hit is found.